### PR TITLE
Fix header line for package.el compatibility

### DIFF
--- a/insfactor.el
+++ b/insfactor.el
@@ -1,4 +1,4 @@
-;;; insfactor.el -- Client for a Clojure project with insfactor in it
+;;; insfactor.el --- Client for a Clojure project with insfactor in it
 
 ;; Copyright (C) 2013 John D. Hume
 


### PR DESCRIPTION
The missing hyphen is causing the package description to be blank in MELPA. :-)
